### PR TITLE
Changes needed to support ppc64le

### DIFF
--- a/ansible/extra/ppc64le.yml
+++ b/ansible/extra/ppc64le.yml
@@ -1,0 +1,18 @@
+# The images below are hand built right now as we work on a broader multi-arch support for Power
+# pull false would ensure that the images are not pulled by docker. This will be removed shortly.
+
+nginx_version: 1.12
+
+couchdb:
+    docker_image: "apache/couchdb-ppc64le:latest"
+    pull_couchdb: false
+
+kafka:
+    docker_image: "kafka-ppc64le:0.10.0"
+    pull_kafka: false
+
+apigateway:
+    docker_image: "openwhisk/apigateway-ppc64le:0.8.2"
+
+#  Because we don't (yet) support s390x/ppc64le compiles of the CLI; a different challenge...
+#  cli_installation_mode: local

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -26,14 +26,17 @@
     couch_image: "{{ couchdb.docker_image | default('apache/couchdb:' ~ couchdb.version ) }}"
 
 - name: "pull the {{ couch_image }} image"
+  vars:
+    pull_image: "{{ couchdb.pull_couchdb | default(true) }}"
   shell: "docker pull {{ couch_image }}"
   retries: "{{ docker.pull.retries }}"
   delay: "{{ docker.pull.delay }}"
+  when: pull_image == true
 
 - name: "(re)start CouchDB"
   docker_container:
     name: couchdb
-    image: apache/couchdb:{{ couchdb.version }}
+    image: "{{ couch_image }}"
     state: started
     recreate: true
     restart_policy: "{{ docker.restart.policy }}"

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -6,9 +6,12 @@
     kafka_image: "{{ kafka.docker_image | default ('wurstmeister/kafka:' ~ kafka.version) }}"
 
 - name: "pull the {{ kafka_image }} image"
+  vars:
+    pull_image: "{{ kafka.pull_kafka | default(true) }}"
   shell: "docker pull {{ kafka_image }}"
   retries: "{{ docker.pull.retries }}"
   delay: "{{ docker.pull.delay }}"
+  when: pull_image == true
 
 - name: (re)start kafka
   vars:

--- a/common/scala/Dockerfile.ppc64le
+++ b/common/scala/Dockerfile.ppc64le
@@ -1,0 +1,9 @@
+FROM buildpack-deps:xenial-curl
+
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+     openjdk-8-jre-headless \
+     wget \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY transformEnvironment.sh /
+RUN chmod +x transformEnvironment.sh

--- a/tools/ubuntu-setup/docker.sh
+++ b/tools/ubuntu-setup/docker.sh
@@ -2,9 +2,22 @@
 set -e
 set -x
 
-sudo apt-get -y install apt-transport-https ca-certificates
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
-sudo sh -c "echo deb https://apt.dockerproject.org/repo ubuntu-trusty main  > /etc/apt/sources.list.d/docker.list"
+sudo apt-get -y install apt-transport-https ca-certificates curl software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo apt-key fingerprint 0EBFCD88
+arch=`uname -m`
+if [ $arch == "ppc64le" ]
+then
+   sudo add-apt-repository \
+   "deb [arch=ppc64el] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+else
+   sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+fi
 sudo apt-get -y update -qq
 
 sudo apt-get purge lxc-docker
@@ -14,7 +27,7 @@ sudo apt-cache policy docker-engine
 sudo apt-get -y install linux-image-extra-$(uname -r)
 
 # DOCKER
-sudo apt-get install -y --force-yes docker-engine=1.12.0-0~trusty
+sudo apt-get install -y --force-yes docker-ce
 
 # enable (security - use 127.0.0.1)
 sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --storage-driver=aufs"'\'' >> /etc/default/docker'

--- a/tools/ubuntu-setup/java8.sh
+++ b/tools/ubuntu-setup/java8.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 set -e
 set -x
-
-sudo apt-get install -y software-properties-common
-sudo add-apt-repository -y ppa:webupd8team/java
-sudo apt-get update -y
-echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections
-sudo apt-get install -y oracle-java8-installer
+arch=`uname -m`
+if [ $arch == "ppc64le" ]
+then
+   sudo apt-get update -y
+   sudo apt-get install openjdk-8-jdk -y
+else
+   sudo apt-get install -y software-properties-common
+   sudo add-apt-repository -y ppa:webupd8team/java
+   sudo apt-get update -y
+   echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections
+   sudo apt-get install -y oracle-java8-installer
+fi


### PR DESCRIPTION
This patch introduces an initial set of changes needed to support
ppc64le as a platform on openwhisk. Some of the changes are probably
not needed in long term once we get multi-arch images available.

The changes are built on top of the PR:3133